### PR TITLE
Handle undefined queryClient when passed as thunk

### DIFF
--- a/packages/svelte-query/src/createBaseQuery.svelte.ts
+++ b/packages/svelte-query/src/createBaseQuery.svelte.ts
@@ -20,7 +20,7 @@ export function createBaseQuery<
     CreateBaseQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>
   >,
   Observer: typeof QueryObserver,
-  queryClientOption?: Accessor<QueryClient>,
+  queryClientOption?: Accessor<QueryClient | undefined>,
 ): CreateBaseQueryResult<TData, TError> {
   /** Load query client */
   const queryClient = $derived(queryClientOption?.())

--- a/packages/svelte-query/src/createQuery.ts
+++ b/packages/svelte-query/src/createQuery.ts
@@ -21,7 +21,7 @@ export function createQuery<
   options: Accessor<
     UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>
   >,
-  queryClient?: Accessor<QueryClient>,
+  queryClient?: Accessor<QueryClient | undefined>,
 ): CreateQueryResult<TData, TError>
 
 export function createQuery<
@@ -33,7 +33,7 @@ export function createQuery<
   options: Accessor<
     DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>
   >,
-  queryClient?: Accessor<QueryClient>,
+  queryClient?: Accessor<QueryClient | undefined>,
 ): DefinedCreateQueryResult<TData, TError>
 
 export function createQuery<
@@ -43,7 +43,7 @@ export function createQuery<
   TQueryKey extends QueryKey = QueryKey,
 >(
   options: Accessor<CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>>,
-  queryClient?: Accessor<QueryClient>,
+  queryClient?: Accessor<QueryClient | undefined>,
 ) {
   return createBaseQuery(options, QueryObserver, queryClient)
 }


### PR DESCRIPTION
Currently, the `queryClient` param is optional, but this doesn't account for a query-creating function like this, where the queryClient is optional. This PR allows undefined to be returned, since undefined is already expected and supported in `useQueryClient`.

```ts
function createMyQuery(ctx: () => { queryClient?: QueryClient }) {
  return createQuery(() => ({
    queryKey: ['mykey'],
    queryFn: () => ({ myreturn: 'cool' }),
  }), () => ctx?.().queryClient); // queryClient returned here may be undefined 
}
```